### PR TITLE
feat: CSV button to download template

### DIFF
--- a/backend/src/services/csv.ts
+++ b/backend/src/services/csv.ts
@@ -38,6 +38,7 @@ export class CSVService {
 
             req.pipe(csvParser())
                 .on('data', (row) => {
+                    const header = Object.keys(row)[0];
                     rowCount++;
                     if (rowCount > 100) {
                         reject(
@@ -46,10 +47,8 @@ export class CSVService {
                         return;
                     }
 
-                    if (Object.keys(row)[0] !== 'keywords') {
-                        reject(
-                            new StandardError(ErrorCodes.API_VALIDATION_ERROR, 'First row must be equals to "keywords"')
-                        );
+                    if (!header.includes('keywords')) {
+                        reject(new StandardError(ErrorCodes.API_VALIDATION_ERROR, 'First row must contain "keywords"'));
                     }
 
                     const values = Object.values(row);

--- a/frontend/public/sample.csv
+++ b/frontend/public/sample.csv
@@ -1,0 +1,4 @@
+keywords<don't change this line! change the lines below instead>
+keyword 1
+keyword 2
+keyword 3

--- a/frontend/src/components/CSV.tsx
+++ b/frontend/src/components/CSV.tsx
@@ -4,25 +4,18 @@ import "../styles/Home.scss";
 
 const CSV: React.FC = () => {
   const handleDownloadCSV = () => {
-    // Get the URL of the CSV template file
     const templateUrl = "/sample.csv";
 
-    // Create an anchor element
     const link = document.createElement("a");
 
-    // Set the href attribute to the template URL
     link.href = templateUrl;
 
-    // Set the download attribute to force download
     link.download = "sample.csv";
 
-    // Trigger a click on the anchor element
     link.click();
   };
 
-  const handleUploadCSV = () => {
-    // Logic to handle upload CSV
-  };
+  const handleUploadCSV = () => {};
 
   return (
     <div className="csv-buttons">

--- a/frontend/src/components/CSV.tsx
+++ b/frontend/src/components/CSV.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import "../styles/Home.scss";
+
+const CSV: React.FC = () => {
+  const handleDownloadCSV = () => {
+    // Get the URL of the CSV template file
+    const templateUrl = "/sample.csv";
+
+    // Create an anchor element
+    const link = document.createElement("a");
+
+    // Set the href attribute to the template URL
+    link.href = templateUrl;
+
+    // Set the download attribute to force download
+    link.download = "sample.csv";
+
+    // Trigger a click on the anchor element
+    link.click();
+  };
+
+  const handleUploadCSV = () => {
+    // Logic to handle upload CSV
+  };
+
+  return (
+    <div className="csv-buttons">
+      <button
+        className="btn btn-primary"
+        onClick={handleDownloadCSV}
+        style={{ marginRight: "10px" }}
+      >
+        Download CSV Template
+      </button>
+      <label htmlFor="csv-upload" className="btn btn-success">
+        Upload CSV
+        <input
+          id="csv-upload"
+          type="file"
+          accept=".csv"
+          style={{ display: "none" }}
+          onChange={handleUploadCSV}
+        />
+      </label>
+    </div>
+  );
+};
+
+export default CSV;

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import CSV from "./CSV";
 
 import "../styles/Home.scss";
 
@@ -31,8 +32,11 @@ const Home: React.FC<HomeProps> = ({ userEmail, keywords }) => {
           </p>
         )}
       </div>
+      <div className="keywords-header-container">
+        <h3 className="keywords-header">Your Keywords:</h3>
+        <CSV />
+      </div>
       <div className="keywords">
-        <h3>Your Keywords:</h3>
         <table className="table table-striped table-bordered">
           <thead>
             <tr>

--- a/frontend/src/configs/env.ts
+++ b/frontend/src/configs/env.ts
@@ -1,2 +1,0 @@
-export const BACKEND_BASE_URL =
-  process.env.BACKEND_URL || "http://localhost:3000";

--- a/frontend/src/configs/env.ts
+++ b/frontend/src/configs/env.ts
@@ -1,0 +1,2 @@
+export const BACKEND_BASE_URL =
+  process.env.BACKEND_URL || "http://localhost:3000";

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -4,7 +4,7 @@ import axios, { AxiosRequestConfig } from "axios";
 import { itemNames } from "../configs/local-storage";
 
 const axiosInstance = axios.create({
-  baseURL: "http://localhost:3000",
+  baseURL: "http://localhost:3000", // TODO: replace with the actual backend baseURL, or even better: use process.env to switch
   timeout: 300000,
 });
 

--- a/frontend/src/styles/Home.scss
+++ b/frontend/src/styles/Home.scss
@@ -29,3 +29,45 @@
     background-color: #d32f2f;
   }
 }
+
+.keywords {
+  display: flex;
+  /* Group elements in the same line */
+  align-items: center;
+  /* Align elements vertically */
+}
+
+.keywords-header-container {
+  display: flex;
+  /* Group elements in the same line */
+  align-items: center;
+  /* Align elements vertically */
+  margin-bottom: 20px;
+}
+
+.keywords-header {
+  margin-right: auto;
+  /* Push CSV buttons to the right */
+}
+
+.csv-buttons {
+  display: flex;
+  /* Group buttons in the same line */
+  align-items: center;
+  /* Align buttons vertically */
+}
+
+.csv-button {
+  margin-left: 10px;
+  /* Add spacing between the buttons */
+}
+
+.csv-button:first-child {
+  margin-left: 0;
+  /* Remove margin from the first button */
+}
+
+.csv-button + .csv-button {
+  margin-left: 10px;
+  /* Add spacing between adjacent buttons */
+}

--- a/frontend/src/styles/Home.scss
+++ b/frontend/src/styles/Home.scss
@@ -32,42 +32,32 @@
 
 .keywords {
   display: flex;
-  /* Group elements in the same line */
   align-items: center;
-  /* Align elements vertically */
 }
 
 .keywords-header-container {
   display: flex;
-  /* Group elements in the same line */
   align-items: center;
-  /* Align elements vertically */
   margin-bottom: 20px;
 }
 
 .keywords-header {
   margin-right: auto;
-  /* Push CSV buttons to the right */
 }
 
 .csv-buttons {
   display: flex;
-  /* Group buttons in the same line */
   align-items: center;
-  /* Align buttons vertically */
 }
 
 .csv-button {
   margin-left: 10px;
-  /* Add spacing between the buttons */
 }
 
 .csv-button:first-child {
   margin-left: 0;
-  /* Remove margin from the first button */
 }
 
 .csv-button + .csv-button {
   margin-left: 10px;
-  /* Add spacing between adjacent buttons */
 }


### PR DESCRIPTION
**Changelogs**:
- show CSV buttons: download template (functional) and upload CSV (WIP)
- add the CSV template
- update the validation for CSV header value in the backend from `must equal` to `must include`
- add styles for CSV

Preview:
![googlescraper](https://github.com/wildan3105/google-scraper/assets/7030099/108d99ba-b2d0-4935-a3e2-5580da96e8c3)
